### PR TITLE
Private functions cannot be externalized

### DIFF
--- a/contracts/Test.sol
+++ b/contracts/Test.sol
@@ -69,6 +69,7 @@ library Lib {
         return t.x;
     }
 
+    function _notExposable() private {}
 }
 
 interface Iface {

--- a/src/core.ts
+++ b/src/core.ts
@@ -224,6 +224,7 @@ function notNull<T>(value: T): value is NonNullable<T> {
 
 function isExternalizable(fnDef: FunctionDefinition): boolean {
   return fnDef.kind !== 'constructor'
+    && fnDef.visibility !== 'private'
     && fnDef.implemented
     && !fnDef.returnParameters.parameters.some(p => p.typeName?.nodeType === 'Mapping');
 }


### PR DESCRIPTION
Right now, the plugin will try to expose private functions in libraries.

There are two options to fix that:

1. Change the `getFunctions` semantics so that subset could be `public,internal` or `!private`
2. Don't change the `getFunctions`, and just mark the private functions as non exposable.

This PR implements the 2nd option.