### PR TITLE
Add `prefix` type to `ExposedConfig`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v4
       with:
-        node-version: 14.x
+        node-version: 18.x
     - name: npm install and build
       run: npm ci
     - name: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.17
+
+- Add `prefix` type to `ExposedConfig`
+
 ## 0.3.16
 
 - Make all exposed internal functions payable.

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export interface ExposedUserConfig {
 }
 
 export interface ExposedConfig extends ExposedUserConfig {
+  prefix: string;
   exclude: string[];
   include: string[];
   outDir: string;

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -6,6 +6,7 @@ import { BuildInfo } from 'hardhat/types';
 import { getExposed, getExposedPath } from './core';
 
 const baseConfig = {
+  prefix: '$',
   exclude: [],
   include: [],
   outDir: 'contracts-exposed',

--- a/src/core.ts
+++ b/src/core.ts
@@ -17,7 +17,6 @@ export interface SolcOutput {
 }
 
 const exposedVersionPragma = '>=0.6.0';
-const defaultPrefix = '$';
 
 interface Config {
   paths: ProjectPathsConfig,
@@ -99,7 +98,7 @@ function getExposedFile(paths: ProjectPathsConfig, ast: SourceUnit, deref: ASTDe
   const dirname = path.dirname(exposedPath);
 
   const relativizePath = (p: string) => (p.startsWith(sourcesPathPrefix) ? path.relative(dirname, p) : p).replace(/\\/g, '/');
-  const content = getExposedContent(ast, relativizePath, deref, initializers, prefix, filter);
+  const content = getExposedContent(ast, relativizePath, deref, prefix, initializers, filter);
 
   if (content === undefined) {
     return undefined;
@@ -117,7 +116,7 @@ function getExposedFile(paths: ProjectPathsConfig, ast: SourceUnit, deref: ASTDe
   };
 }
 
-function getExposedContent(ast: SourceUnit, relativizePath: (p: string) => string, deref: ASTDereferencer, initializers = false, prefix = defaultPrefix, filter?: ContractFilter): FileContent | undefined {
+function getExposedContent(ast: SourceUnit, relativizePath: (p: string) => string, deref: ASTDereferencer, prefix: string, initializers = false, filter?: ContractFilter): FileContent | undefined {
   if (prefix === '' || /^\d|[^0-9a-z_$]/i.test(prefix)) {
     throw new Error(`Prefix '${prefix}' is not valid`);
   }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -14,6 +14,7 @@ import type {} from './type-extensions';
 extendConfig((config, { exposed: userConfig }) => {
   config.exposed = {
     ...userConfig,
+    prefix: userConfig?.prefix ?? '$',
     exclude: userConfig?.exclude ?? [],
     include: userConfig?.include ?? ['**/*'],
     outDir: userConfig?.outDir ?? "contracts-exposed",


### PR DESCRIPTION
I'm accessing the `prefix` config value because I need to load batches of "exposed" contracts programmatically.  It seems like it should be included in the `ExposedConfig` type as a required value, treated the same as `outDir`.